### PR TITLE
Ajuste no teste para não consultar a API, que pode estar temporariamente off

### DIFF
--- a/src/CepProviders/BrasilApiV2.php
+++ b/src/CepProviders/BrasilApiV2.php
@@ -27,7 +27,7 @@ class BrasilApiV2 extends BaseCepProvider
     public function get(string $cep): ?CepEntity
     {
         try {
-            $data = $this->client->get("{$this->formatCep($cep)}.json")
+            $data = $this->client->get("{$this->formatCep($cep)}")
                                  ->object();
 
             $this->setOriginalProviderResponse($data);


### PR DESCRIPTION
Esse ajuste visa testar o código e não se a API está realmente de funcionando, fazendo com que os testes passem sem problemas