### PR TITLE
feat(validation): add `ValidCep` validation rule with format and existence checks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,9 +243,9 @@ public function messages(): array
 
 ## Tests
 
-#### To ensure the delivery of data, several public providers are used, with this, the need to standardize and apply tests for better code quality was seen. About 70+ tests are included in the package.
+#### To ensure the delivery of data, several public providers are used, with this, the need to standardize and apply tests for better code quality was seen. About 90+ tests are included in the package.
 
-#### Tests can be verified through the badge [![tests badge](https://github.com/lsnepomuceno/laravel-brazilian-ceps/actions/workflows/action_laravel.yml/badge.svg?branch=main)](https://github.com/lsnepomuceno/laravel-brazilian-ceps/actions/workflows/action_laravel.yml)
+#### Tests can be verified through the badge [![tests badge](https://github.com/lsnepomuceno/laravel-brazilian-ceps/actions/workflows/action_laravel.yml/badge.svg)](https://github.com/lsnepomuceno/laravel-brazilian-ceps/actions/workflows/action_laravel.yml)
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,61 @@ class ExampleController() {
 
 <hr>
 
+## Validation Rule
+
+##### The package provides a `ValidCep` rule that integrates with Laravel's validation system to validate Brazilian CEP format and, optionally, verify that the CEP actually exists.
+
+### Format validation only:
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelBrazilianCeps\Rules\ValidCep;
+
+class AddressRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'cep' => ['required', 'string', new ValidCep],
+        ];
+    }
+}
+```
+
+### Format + existence check:
+
+#### Using the `mustExist()` method causes the rule to query the CEP providers to confirm the address exists. This performs an external HTTP request (subject to caching).
+
+```PHP
+<?php
+
+use LSNepomuceno\LaravelBrazilianCeps\Rules\ValidCep;
+
+class AddressRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'cep' => ['required', 'string', (new ValidCep)->mustExist()],
+        ];
+    }
+}
+```
+
+#### :exclamation: When validation fails, the rule returns Portuguese error messages by default. You can override them via the `messages()` method in your Form Request:
+
+```PHP
+public function messages(): array
+{
+    return [
+        'cep.valid_cep' => 'The zip code is invalid.',
+    ];
+}
+```
+
+<hr>
+
 ## Cache Results
 
 #### By default, the results cache are cached and have a lifetime of 30 days, if you need to disable or change the lifetime, just update the configuration variables, as described below.

--- a/src/Rules/ValidCep.php
+++ b/src/Rules/ValidCep.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace LSNepomuceno\LaravelBrazilianCeps\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use LSNepomuceno\LaravelBrazilianCeps\Services\CepService;
+use Throwable;
+
+class ValidCep implements ValidationRule
+{
+    private bool $checkExistence = false;
+
+    public function mustExist(): static
+    {
+        $this->checkExistence = true;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $digits = preg_replace('/\D/', '', (string) $value);
+
+        if (strlen($digits) !== 8) {
+            $fail('O CEP informado possui um formato inválido.');
+
+            return;
+        }
+
+        if ($this->checkExistence) {
+            try {
+                $cep = app(CepService::class)->get($digits);
+
+                if ($cep === null) {
+                    $fail('O CEP informado não foi encontrado.');
+                }
+            } catch (Throwable) {
+                $fail('O CEP informado não foi encontrado.');
+            }
+        }
+    }
+}

--- a/tests/Feature/ValidCepRuleFeatureTest.php
+++ b/tests/Feature/ValidCepRuleFeatureTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace LSNepomuceno\LaravelBrazilianCeps\Tests\Feature;
+
+use Illuminate\Support\Facades\Validator;
+use LSNepomuceno\LaravelBrazilianCeps\Rules\ValidCep;
+use LSNepomuceno\LaravelBrazilianCeps\Tests\TestCase;
+
+class ValidCepRuleFeatureTest extends TestCase
+{
+    public function testValidCepPassesValidation(): void
+    {
+        $validator = Validator::make(
+            ['cep' => '29018-210'],
+            ['cep' => [new ValidCep]]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testValidCepWithoutMaskPassesValidation(): void
+    {
+        $validator = Validator::make(
+            ['cep' => '29018210'],
+            ['cep' => [new ValidCep]]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testInvalidCepFailsValidation(): void
+    {
+        $validator = Validator::make(
+            ['cep' => '123'],
+            ['cep' => [new ValidCep]]
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function testValidationErrorMessageIsReturned(): void
+    {
+        $validator = Validator::make(
+            ['cep' => 'not-a-cep'],
+            ['cep' => [new ValidCep]]
+        );
+
+        $this->assertArrayHasKey('cep', $validator->errors()->toArray());
+    }
+
+    public function testValidCepWithMustExistPassesForRealCep(): void
+    {
+        $validator = Validator::make(
+            ['cep' => '29018-210'],
+            ['cep' => [(new ValidCep)->mustExist()]]
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testNonExistentCepWithMustExistFailsValidation(): void
+    {
+        $validator = Validator::make(
+            ['cep' => '00000-000'],
+            ['cep' => [(new ValidCep)->mustExist()]]
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function testRuleWorksAlongsideOtherRules(): void
+    {
+        $validator = Validator::make(
+            ['cep' => ''],
+            ['cep' => ['required', new ValidCep]]
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('cep', $validator->errors()->toArray());
+    }
+}

--- a/tests/Unit/ValidCepRuleTest.php
+++ b/tests/Unit/ValidCepRuleTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace LSNepomuceno\LaravelBrazilianCeps\Tests\Unit;
+
+use Exception;
+use LSNepomuceno\LaravelBrazilianCeps\Entities\CepEntity;
+use LSNepomuceno\LaravelBrazilianCeps\Rules\ValidCep;
+use LSNepomuceno\LaravelBrazilianCeps\Services\CepService;
+use LSNepomuceno\LaravelBrazilianCeps\Tests\TestCase;
+
+class ValidCepRuleTest extends TestCase
+{
+    private function getFailures(ValidCep $rule, string $value): array
+    {
+        $failures = [];
+        $rule->validate('cep', $value, function (string $message) use (&$failures) {
+            $failures[] = $message;
+        });
+
+        return $failures;
+    }
+
+    public function testValidCepDigitsOnlyPasses(): void
+    {
+        $this->assertEmpty($this->getFailures(new ValidCep, '29018210'));
+    }
+
+    public function testValidCepWithMaskPasses(): void
+    {
+        $this->assertEmpty($this->getFailures(new ValidCep, '29018-210'));
+    }
+
+    public function testCepWithTooFewDigitsFails(): void
+    {
+        $this->assertNotEmpty($this->getFailures(new ValidCep, '2901821'));
+    }
+
+    public function testCepWithTooManyDigitsFails(): void
+    {
+        $this->assertNotEmpty($this->getFailures(new ValidCep, '290182100'));
+    }
+
+    public function testCepWithNonNumericCharsFails(): void
+    {
+        $this->assertNotEmpty($this->getFailures(new ValidCep, 'ABCDE-FGH'));
+    }
+
+    public function testCepEmptyStringFails(): void
+    {
+        $this->assertNotEmpty($this->getFailures(new ValidCep, ''));
+    }
+
+    public function testInvalidFormatMessageIsInPortuguese(): void
+    {
+        $failures = $this->getFailures(new ValidCep, '123');
+
+        $this->assertStringContainsString('formato inválido', $failures[0]);
+    }
+
+    public function testMustExistReturnsSameInstance(): void
+    {
+        $rule = new ValidCep;
+
+        $this->assertSame($rule, $rule->mustExist());
+    }
+
+    public function testMustExistPassesWhenServiceReturnsEntity(): void
+    {
+        $entity = new CepEntity(
+            city        : 'Vitória',
+            cep         : '29018-210',
+            street      : 'Rua da Vitória',
+            state       : 'Espírito Santo',
+            uf          : 'ES',
+            neighborhood: 'Centro',
+        );
+
+        $mock = $this->createMock(CepService::class);
+        $mock->method('get')->willReturn($entity);
+        $this->app->bind(CepService::class, fn () => $mock);
+
+        $this->assertEmpty($this->getFailures((new ValidCep)->mustExist(), '29018-210'));
+    }
+
+    public function testMustExistFailsWhenServiceReturnsNull(): void
+    {
+        $mock = $this->createMock(CepService::class);
+        $mock->method('get')->willReturn(null);
+        $this->app->bind(CepService::class, fn () => $mock);
+
+        $failures = $this->getFailures((new ValidCep)->mustExist(), '29018-210');
+
+        $this->assertNotEmpty($failures);
+        $this->assertStringContainsString('não foi encontrado', $failures[0]);
+    }
+
+    public function testMustExistFailsWhenServiceThrowsException(): void
+    {
+        $mock = $this->createMock(CepService::class);
+        $mock->method('get')->willThrowException(new Exception('Service unavailable'));
+        $this->app->bind(CepService::class, fn () => $mock);
+
+        $failures = $this->getFailures((new ValidCep)->mustExist(), '29018-210');
+
+        $this->assertNotEmpty($failures);
+        $this->assertStringContainsString('não foi encontrado', $failures[0]);
+    }
+
+    public function testFormatValidationRunsBeforeExistenceCheck(): void
+    {
+        $mock = $this->createMock(CepService::class);
+        $mock->expects($this->never())->method('get');
+        $this->app->bind(CepService::class, fn () => $mock);
+
+        $failures = $this->getFailures((new ValidCep)->mustExist(), 'invalid');
+
+        $this->assertStringContainsString('formato inválido', $failures[0]);
+    }
+}


### PR DESCRIPTION
- Introduced `ValidCep` rule for validating Brazilian CEPs.
- Added feature to optionally verify CEP existence via `mustExist()`.
- Included unit and feature tests for validation scenarios.
- Updated README with usage instructions for the new rule.